### PR TITLE
fix the GitHub stats card error

### DIFF
--- a/.github/workflows/regen-on-fire.yml
+++ b/.github/workflows/regen-on-fire.yml
@@ -83,14 +83,19 @@ jobs:
           '
 
       # ── GitHub stats cards (non-blocking) ──────────────────────
+      # readme-tools/github-readme-stats-action's "stats" card runs one
+      # combined GraphQL query for everything; for this account, several of
+      # its fields are cheap alone but trip RESOURCE_LIMITS_EXCEEDED when
+      # fetched together (not a rate-limit issue — retrying/PATs don't help).
+      # generate-stats-card.mjs fetches the same data as a few small, safe
+      # queries instead. Top Languages is unaffected and keeps using the action.
       - name: Generate GitHub stats card
         continue-on-error: true
-        uses: readme-tools/github-readme-stats-action@v1
-        with:
-          card: stats
-          options: "username=${{ github.repository_owner }}&&show_icons=true&&theme=tokyonight&&hide_border=true"
-          path: profile/stats.svg
-          token: ${{ secrets.CONTRIBUTIONS_PAT || secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONTRIBUTIONS_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_USERNAME: ${{ github.repository_owner }}
+        run: |
+          node scripts/generate-stats-card.mjs
 
       - name: Generate Top Languages card
         continue-on-error: true
@@ -100,6 +105,16 @@ jobs:
           options: "username=${{ github.repository_owner }}&&layout=compact&&theme=tokyonight&&hide_border=true"
           path: profile/top-langs.svg
           token: ${{ secrets.CONTRIBUTIONS_PAT || secrets.GITHUB_TOKEN }}
+
+      # Guard against the Top Languages action still writing an error card
+      # (e.g. transient rate limiting) — never let that overwrite a good one.
+      - name: Discard top-langs card if it rendered as an error
+        if: always()
+        run: |
+          if [ -f profile/top-langs.svg ] && grep -q "Something went wrong" profile/top-langs.svg; then
+            echo "profile/top-langs.svg rendered an error card; keeping previous version."
+            git checkout -- profile/top-langs.svg || rm -f profile/top-langs.svg
+          fi
 
       # ── Commit & push (only if something changed) ─────────────
       - name: Commit changes

--- a/profile/stats.svg
+++ b/profile/stats.svg
@@ -1,15 +1,30 @@
-
-    <svg width="576.5"  height="120" viewBox="0 0 576.5 120" fill="#1a1b27" xmlns="http://www.w3.org/2000/svg">
-    <style>
-    .text { font: 600 16px 'Segoe UI', Ubuntu, Sans-Serif; fill: #70a5fd }
-    .small { font: 600 12px 'Segoe UI', Ubuntu, Sans-Serif; fill: #38bdae }
-    .gray { fill: #858585 }
-    </style>
-    <rect x="0.5" y="0.5" width="575.5" height="99%" rx="4.5" fill="#1a1b27" stroke="#e4e2e2"/>
-    <text x="25" y="45" class="text">Something went wrong! file an issue at https://tiny.one/readme-stats</text>
-    <text data-testid="message" x="25" y="55" class="text small">
-      <tspan x="25" dy="18">Resource limits for this query exceeded.</tspan>
-      <tspan x="25" dy="18" class="gray">OK</tspan>
-    </text>
-    </svg>
+<svg width="300" height="180" viewBox="0 0 300 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .header { font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif; fill: #70a5fd; }
+    .label { font: 400 13px 'Segoe UI', Ubuntu, Sans-Serif; fill: #38bdae; }
+    .value { font: 600 13px 'Segoe UI', Ubuntu, Sans-Serif; fill: #ffffff; }
+  </style>
+  <rect data-testid="card-bg" x="0.5" y="0.5" rx="4.5" width="299" height="179" fill="#1a1b27" stroke="#e4e2e2" stroke-opacity="0"/>
+  <text x="25" y="30" class="header">nazarli-shabnam's GitHub Stats</text>
   
+    <g transform="translate(25, 55)">
+      <text class="label" x="0" y="0">Total Stars</text>
+      <text class="value" x="250" y="0" text-anchor="end">554</text>
+    </g>
+    <g transform="translate(25, 80)">
+      <text class="label" x="0" y="0">Total Commits</text>
+      <text class="value" x="250" y="0" text-anchor="end">2052</text>
+    </g>
+    <g transform="translate(25, 105)">
+      <text class="label" x="0" y="0">Total PRs</text>
+      <text class="value" x="250" y="0" text-anchor="end">612</text>
+    </g>
+    <g transform="translate(25, 130)">
+      <text class="label" x="0" y="0">Total Issues</text>
+      <text class="value" x="250" y="0" text-anchor="end">481</text>
+    </g>
+    <g transform="translate(25, 155)">
+      <text class="label" x="0" y="0">Followers</text>
+      <text class="value" x="250" y="0" text-anchor="end">54</text>
+    </g>
+</svg>

--- a/scripts/generate-stats-card.mjs
+++ b/scripts/generate-stats-card.mjs
@@ -1,0 +1,163 @@
+/**
+ * Renders profile/stats.svg ourselves instead of relying on
+ * readme-tools/github-readme-stats-action.
+ *
+ * That action's "stats" card runs one combined GraphQL query for everything
+ * (commits, PRs, issues, contributedTo, repos+stargazers, ...). For this
+ * account the combined cost of several of those fields together trips
+ * GitHub's RESOURCE_LIMITS_EXCEEDED guard — each field is cheap on its own,
+ * but computing them together in a single request is not. Splitting the
+ * same data across a few small, targeted requests avoids that entirely.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const TOKEN = process.env.GITHUB_TOKEN;
+const USERNAME = process.env.GITHUB_USERNAME;
+const OUT_PATH = path.join(process.cwd(), "profile", "stats.svg");
+
+if (!TOKEN) throw new Error("Missing GITHUB_TOKEN");
+if (!USERNAME) throw new Error("Missing GITHUB_USERNAME");
+
+async function ghGraphQL(query, variables) {
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`GraphQL request failed ${res.status}: ${txt}`);
+  }
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors, null, 2));
+  return json.data;
+}
+
+async function fetchTotalStars() {
+  let total = 0;
+  let cursor = null;
+  let hasMore = true;
+  while (hasMore) {
+    const query = `
+      query ($login: String!, $cursor: String) {
+        user(login: $login) {
+          repositories(ownerAffiliations: OWNER, first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes { stargazerCount }
+          }
+        }
+      }
+    `;
+    const data = await ghGraphQL(query, { login: USERNAME, cursor });
+    const repos = data.user.repositories;
+    for (const repo of repos.nodes) total += repo.stargazerCount;
+    hasMore = repos.pageInfo.hasNextPage;
+    cursor = repos.pageInfo.endCursor;
+  }
+  return total;
+}
+
+async function fetchTotalCommits() {
+  const query = `
+    query ($login: String!) {
+      user(login: $login) {
+        contributionsCollection { totalCommitContributions }
+      }
+    }
+  `;
+  const data = await ghGraphQL(query, { login: USERNAME });
+  return data.user.contributionsCollection.totalCommitContributions;
+}
+
+async function fetchTotalPRs() {
+  const query = `
+    query ($login: String!) {
+      user(login: $login) {
+        pullRequests(first: 1) { totalCount }
+      }
+    }
+  `;
+  const data = await ghGraphQL(query, { login: USERNAME });
+  return data.user.pullRequests.totalCount;
+}
+
+async function fetchIssuesAndFollowers() {
+  const query = `
+    query ($login: String!) {
+      user(login: $login) {
+        openIssues: issues(states: OPEN) { totalCount }
+        closedIssues: issues(states: CLOSED) { totalCount }
+        followers { totalCount }
+      }
+    }
+  `;
+  const data = await ghGraphQL(query, { login: USERNAME });
+  return {
+    issues: data.user.openIssues.totalCount + data.user.closedIssues.totalCount,
+    followers: data.user.followers.totalCount,
+  };
+}
+
+function escapeXml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function statsCardSvg(stats) {
+  const rows = [
+    ["Total Stars", stats.stars],
+    ["Total Commits", stats.commits],
+    ["Total PRs", stats.prs],
+    ["Total Issues", stats.issues],
+    ["Followers", stats.followers],
+  ];
+
+  const W = 300;
+  const rowHeight = 25;
+  const H = 55 + rows.length * rowHeight;
+
+  const rowsSvg = rows
+    .map(
+      (row, i) => `
+    <g transform="translate(25, ${55 + i * rowHeight})">
+      <text class="label" x="0" y="0">${escapeXml(row[0])}</text>
+      <text class="value" x="${W - 50}" y="0" text-anchor="end">${escapeXml(row[1])}</text>
+    </g>`
+    )
+    .join("");
+
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .header { font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif; fill: #70a5fd; }
+    .label { font: 400 13px 'Segoe UI', Ubuntu, Sans-Serif; fill: #38bdae; }
+    .value { font: 600 13px 'Segoe UI', Ubuntu, Sans-Serif; fill: #ffffff; }
+  </style>
+  <rect data-testid="card-bg" x="0.5" y="0.5" rx="4.5" width="${W - 1}" height="${H - 1}" fill="#1a1b27" stroke="#e4e2e2" stroke-opacity="0"/>
+  <text x="25" y="30" class="header">${escapeXml(USERNAME)}'s GitHub Stats</text>
+  ${rowsSvg}
+</svg>`;
+}
+
+async function main() {
+  const [stars, commits, prs, { issues, followers }] = await Promise.all([
+    fetchTotalStars(),
+    fetchTotalCommits(),
+    fetchTotalPRs(),
+    fetchIssuesAndFollowers(),
+  ]);
+
+  const svg = statsCardSvg({ stars, commits, prs, issues, followers });
+  fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  fs.writeFileSync(OUT_PATH, svg, "utf8");
+  console.log("Wrote profile/stats.svg with", { stars, commits, prs, issues, followers });
+}
+
+await main();


### PR DESCRIPTION
## Summary
Follow-up to #28 — that PR's fix (swap to `CONTRIBUTIONS_PAT`) turned out to only paper over the symptom, not the root cause:

- Reproduced the actual GraphQL query directly against the API: several of its fields (`pullRequests`, `contributionsCollection`, `repositoriesContributedTo`, ...) each succeed individually, but combining them in one request trips `RESOURCE_LIMITS_EXCEEDED` for this account — regardless of which token is used. That's why the PAT swap didn't help; the last run after merging #28 still failed identically.
- Since `readme-tools/github-readme-stats-action`'s "stats" card always issues that one combined query with no option to split it, `scripts/generate-stats-card.mjs` now fetches the same numbers (stars, commits, PRs, issues, followers) as a few small, independently-safe GraphQL queries and renders `profile/stats.svg` itself, matching the existing card's color theme.
- Top Languages card is untouched (never affected), but added a guard so it can never overwrite itself with an error card if it ever does fail transiently.
- Regenerated `profile/stats.svg` locally against the real API to confirm it renders correctly now (stars: 554, commits: 2052, PRs: 612, issues: 481, followers: 54).

## Test plan
- [x] Ran `node scripts/generate-stats-card.mjs` locally against the real GitHub API — succeeds, no resource-limit error, `profile/stats.svg` renders real numbers instead of the error card.
- [ ] Confirm on the next scheduled/dispatched workflow run that `profile/stats.svg` keeps rendering correctly in CI.